### PR TITLE
Update wallets.jade to include Coinomi

### DIFF
--- a/src/docs/wallets.jade
+++ b/src/docs/wallets.jade
@@ -50,6 +50,7 @@ block information
     +wallet("AirBitz", "iOS, Android", "checkmark", "", "https://airbitz.co/")
     +wallet("Armory", "Mac OS, Windows, Linux", "checkmark", "", "https://bitcoinarmory.com/")
     +wallet("Blockchain", "iOS, Android, Web", "checkmark", "", "https://blockchain.info/wallet")
+    +wallet("Coinomi", "Android", "checkmark", "", "https://coinomi.com/")
     +wallet("Electrum", "Mac OS, Windows, Linux", "checkmark", "", "https://electrum.org/")
     +wallet("GreenAddress", "Chrome, iOS, Android", "checkmark", "", "https://greenaddress.it/")
     +wallet("KryptoKit", "Chrome", "checkmark", "", "https://chrome.google.com/webstore/detail/kryptokit-bitcoin-wallet/lhhipingoaiddcoalochnbjlkifbpmoj")


### PR DESCRIPTION
Added Coinomi wallet for Android. BIP 21 supported, BIP 70-72 not supported.