### PR TITLE
Add Check for Payment Protocol Support for Airbitz Wallet

### DIFF
--- a/src/docs/wallets.jade
+++ b/src/docs/wallets.jade
@@ -128,7 +128,7 @@ block information
         +ios()
         +android()
       td.checkmark
-      td
+      td.checkmark
     
     +wallet("Armory", "https://bitcoinarmory.com/")
       td.text-left


### PR DESCRIPTION
Airbitz recently added BIP70 support to its wallet. This PR updates the /docs/wallets page to reflect this. 