### PR TITLE
Remove Hive Wallet

### DIFF
--- a/src/docs/wallets.jade
+++ b/src/docs/wallets.jade
@@ -107,15 +107,6 @@ block information
       td.checkmark
       td.checkmark
     
-    +wallet("Hive", "https://www.hivewallet.com/")
-      td.text-left
-        +ios()
-        +android()
-        +mac()
-        +web()
-      td.checkmark
-      td.checkmark
-        
     +wallet("Mycelium", "https://play.google.com/store/apps/details?id=com.mycelium.wallet")
       td.text-left
         +ios()


### PR DESCRIPTION
This removes unsupported Hive Wallet from bitpay.com/docs/bitcoin-wallet-comparison