### PR TITLE
Fix for pricing page confusion

### DIFF
--- a/src/pricing.jade
+++ b/src/pricing.jade
@@ -22,9 +22,9 @@ block content
         .row
           div.border-top-gray(style="height:85px")
             div(style="padding-top:1em")
-              | Up to $1,000 / Day,
-              br
               | 30 Transactions / Month
+              br
+              small Up to $1,000 / Day. 1% for Additional Transactions
           div.border-top-gray(style="height:105px")
             div.padding-vertical-less.bold Login Access
             div Single User

--- a/src/pricing.jade
+++ b/src/pricing.jade
@@ -24,7 +24,7 @@ block content
             div(style="padding-top:1em")
               | 30 Transactions / Month
               br
-              small Up to $1,000 / Day. 1% for Additional Transactions
+              small 1% Service Fee For Each Additional Transaction
           div.border-top-gray(style="height:105px")
             div.padding-vertical-less.bold Login Access
             div Single User


### PR DESCRIPTION
Added a line to help prospects to see what happens after you've reached your starter plan limit.